### PR TITLE
QT5 -no-nis incompatibility

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -46,7 +46,6 @@ $(package)_config_opts += -no-linuxfb
 $(package)_config_opts += -no-libudev
 $(package)_config_opts += -no-mitshm
 $(package)_config_opts += -no-mtdev
-$(package)_config_opts += -no-nis
 $(package)_config_opts += -no-pulseaudio
 $(package)_config_opts += -no-openvg
 $(package)_config_opts += -no-reduce-relocations


### PR DESCRIPTION
#$(package)_config_opts += -no-nis  - Incompatible with current QT5
depends for ARM in this case