### PR TITLE
[depends] update bdb.mk for mac compile

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -14,7 +14,9 @@ $(package)_cxxflags=-std=c++11
 endef
 
 define $(package)_preprocess_cmds
-  sed -i -e "s/WinIoCtl.h/winioctl.h/g" src/dbinc/win_db.h
+  sed -i.old 's/WinIoCtl.h/winioctl.h/g' src/dbinc/win_db.h &&
+  sed -i.old 's/__atomic_compare_exchange(/__atomic_compare_exchange_db(/' src/dbinc/atomic.h &&
+  sed -i.old 's/atomic_init/atomic_init_db/' src/dbinc/atomic.h src/mp/mp_region.c src/mp/mp_mvcc.c src/mp/mp_fget.c src/mutex/mut_method.c src/mutex/mut_tas.c
 endef
 
 define $(package)_config_cmds


### PR DESCRIPTION
Cross compile for MAC was broken for BDB 6.2.32

Zcoin is using also using 6.2. Relevant lines were copied from:
https://github.com/zcash/zcash/blob/master/depends/packages/bdb.mk

these lines:
sed -i.old 's/WinIoCtl.h/winioctl.h/g' src/dbinc/win_db.h &&
sed -i.old 's/__atomic_compare_exchange(/__atomic_compare_exchange_db(/' src/dbinc/atomic.h &&
sed -i.old 's/atomic_init/atomic_init_db/' src/dbinc/atomic.h src/mp/mp_region.c src/mp/mp_mvcc.c src/mp/mp_fget.c src/mutex/mut_method.c src/mutex/mut_tas.c
